### PR TITLE
서버사이드렌더링 방식으로 리스트 출력 및 갱신하기

### DIFF
--- a/public/js/mypage.js
+++ b/public/js/mypage.js
@@ -6,6 +6,7 @@ const del_btn = document.querySelectorAll('.group-list__del-btn');
 const no_btn = document.querySelectorAll('.modal__no-btn');
 const edit_btn = document.querySelectorAll('.group-list__edit-btn');
 const group_enter_btn = document.querySelectorAll('.group-list__enter-btn');
+const reloadLeadGroupBtn = document.querySelector('.group-list__load-btn');
 
 function redirectEditPage() {
   location.href = 'http://localhost:3000/mypage/edit-myinfo';
@@ -21,6 +22,10 @@ function openModal(modal) {
 function closeModal() {
   const cur_modal = this.closest('.show-modal');
   cur_modal.classList.remove('show-modal');
+}
+
+function reloadLeadGroup() {
+  location.href = 'http://localhost:3000/mypage?reload=true';
 }
 
 function init() {
@@ -40,6 +45,8 @@ function init() {
   edit_btn.forEach(Item => {
     Item.addEventListener('click', redeirectGroupEditPage);
   });
+  // 진행 중인 스터디 더 보기
+  reloadLeadGroupBtn.addEventListener('click', reloadLeadGroup);
 }
 
 init();

--- a/routes/mypage.js
+++ b/routes/mypage.js
@@ -14,14 +14,52 @@ function isLoggedIn(req) {
 }
 
 // Mypage Route
+let idx = 0;
+let dataArray = [];
 router.get('/', (req, res, next) => {
   if (!req.user) {
     res.redirect('/auth/sign-in');
-  } else {
-    res.render('mypage', {
-      isLoggedIn: isLoggedIn(req),
-      path: req.baseUrl,
-      nickname: req.user.nickname
+  }
+  // 다른 페이지에서 마이페이지로 접속한 경우 (= 쿼리 스트링이 없다)
+  if (!req.query.reload) {
+    idx = 0;
+    dataArray = [];
+    const sql = `SELECT * FROM study_group WHERE idx BETWEEN ${idx + 1} AND ${
+      idx + 4
+    }`;
+    console.log('idx: ', idx);
+    db.query(sql, (err, results) => {
+      if (err) {
+        next(err);
+      }
+      idx += 4;
+      dataArray.push(...results);
+      res.render('mypage', {
+        isLoggedIn: isLoggedIn(req),
+        path: req.baseUrl,
+        nickname: req.user.nickname,
+        dataArray: dataArray
+      });
+    });
+  }
+  // 마이페이지에서 리스트 갱신이 실행된 경우 (= /mypage?reload=true)
+  if (req.query.reload === 'true') {
+    const sql = `SELECT * FROM study_group WHERE idx BETWEEN ${idx + 1} AND ${
+      idx + 4
+    }`;
+    console.log('idx: ', idx);
+    db.query(sql, (err, results) => {
+      if (err) {
+        next(err);
+      }
+      idx += 4;
+      dataArray.push(...results);
+      res.render('mypage', {
+        isLoggedIn: isLoggedIn(req),
+        path: req.baseUrl,
+        nickname: req.user.nickname,
+        dataArray: dataArray
+      });
     });
   }
 });

--- a/views/includes/mypage/join-group-list.ejs
+++ b/views/includes/mypage/join-group-list.ejs
@@ -17,7 +17,7 @@
   </div>
 </div>
 <!-- TEST DATA!!! -->
-<% for(let i = 0; i < 5; i++) { %>
+<!-- <% for(let i = 0; i < 5; i++) { %>
 <div class="group-list__item">
   <div class="group-tag">
     <div class="group-tag__cat-main">대분류</div>
@@ -34,4 +34,4 @@
     <button class="group-list__desc-btn">자세히 보기</button>
   </div>
 </div>
-<% } %>
+<% } %> -->

--- a/views/includes/mypage/lead-group-list.ejs
+++ b/views/includes/mypage/lead-group-list.ejs
@@ -15,8 +15,20 @@
     <span class="group-list__name"><%= data.name %></span>
   </div>
   <div class="group-list__mgr">
-    <button class="group-list__del-btn">삭제</button>
-    <button class="group-list__edit-btn">관리</button>
+    <form
+      class="group-edit__form"
+      action="/mypage/group-edit/process"
+      method="POST"
+    >
+      <input
+        class="group-list__hidden-input"
+        name="study-group-id"
+        type="hidden"
+        value="<%= data.id %>"
+      />
+      <button class="group-list__del-btn">삭제</button>
+      <button class="group-list__edit-btn">관리</button>
+    </form>
   </div>
 </div>
 <% }) %>

--- a/views/includes/mypage/lead-group-list.ejs
+++ b/views/includes/mypage/lead-group-list.ejs
@@ -1,37 +1,23 @@
 <span class="group-list__text">진행 중인 스터디</span>
-<!-- 내가 모집한 스터디 목록 -->
+<!-- Load data -->
+<% dataArray.forEach(data => { %>
 <div class="group-list__item">
   <div class="group-tag">
-    <div class="group-tag__cat-main">대분류</div>
-    <div class="group-tag__cat-sub">중분류</div>
-    <div class="group-tag__loc">장소</div>
-    <div class="group-tag__gndr">성별</div>
+    <div class="group-tag__cat-main"><%= data.main_category %></div>
+    <div class="group-tag__cat-sub"><%= data.sub_category %></div>
+    <div class="group-tag__loc"><%= data.location %></div>
+    <div class="group-tag__gndr"><%= data.gender %></div>
   </div>
   <div class="group-list__info">
-    <span class="group-list__num">3/5</span>
-    <span class="group-list__name">스터디 이름</span>
+    <span class="group-list__num">
+      <%= data.current_number + '/' + data.maximum_number %>
+    </span>
+    <span class="group-list__name"><%= data.name %></span>
   </div>
   <div class="group-list__mgr">
     <button class="group-list__del-btn">삭제</button>
     <button class="group-list__edit-btn">관리</button>
   </div>
 </div>
-<!-- TEST DATA!!! -->
-<% for(let i = 0; i < 2; i++) { %>
-<div class="group-list__item">
-  <div class="group-tag">
-    <div class="group-tag__cat-main">대분류</div>
-    <div class="group-tag__cat-sub">중분류</div>
-    <div class="group-tag__loc">장소</div>
-    <div class="group-tag__gndr">성별</div>
-  </div>
-  <div class="group-list__info">
-    <span class="group-list__num">3/5</span>
-    <span class="group-list__name">TEST</span>
-  </div>
-  <div class="group-list__mgr">
-    <button class="group-list__del-btn">삭제</button>
-    <button class="group-list__edit-btn">관리</button>
-  </div>
-</div>
-<% } %>
+<% }) %>
+<button class="group-list__load-btn">더 보기</button>

--- a/views/includes/mypage/lead-group-list.ejs
+++ b/views/includes/mypage/lead-group-list.ejs
@@ -32,4 +32,3 @@
   </div>
 </div>
 <% }) %>
-<button class="group-list__load-btn">더 보기</button>

--- a/views/mypage.ejs
+++ b/views/mypage.ejs
@@ -23,6 +23,7 @@
       <section class="lead-group-list">
         <%- include('includes/mypage/lead-group-list'); %>
       </section>
+      <button class="group-list__load-btn">더 보기</button>
     </main>
     <!-- modals -->
     <%- include('includes/mypage/modal'); %>


### PR DESCRIPTION
## <서버 사이드 렌더링 방식으로 데이터 출력 및 갱신하기>

### 마이페이지 '진행 중인 스터디'로 테스트 진행

+ 메인페이지, 참여 중인 스터디 등 스터디 그룹 정보를 사용하는 모든 페이지에 동일한 방식으로 적용 가능
+ 현재는 임의로 4개씩 데이터를 가져오지만 추후 CSS에 맞게 개수 변경 
+ 현재는 ```더 보기``` 버튼을 사용하여 리스트를 갱신하는 방법으로 테스트했는데, 'scroll' 이벤트를 사용하면 버튼 클릭 대신 스크롤을 통해 리스트 갱신 가능
+ 🚨 DB에서 순차적으로 데이터를 갱신하기 위해, 임의로 study_group 테이블에 idx 컬럼을 생성하여 테스트 했음. 스터디 그룹 생성 시 idx 컬럼에 auto_increment로 idx 번호가 생성된다.  **단! 스터디를 삭제하면 해당 idx 번호가 사라진다. 이 경우 1,2,3,4 순서였던 study_group 테이블 idx가 1,2,4 처럼 중간에 빌 수도 있는데 이 경우는 일단 고려하지 않고 진행했음. 추후 DB에서 순서대로 데이터를 카운트하여 전달할 수 있는 방법을 모색해야 할듯**
+ 🚨🚨 현재 '사용자를 식별하여 해당 사용자의 스터디를 가지고 오는 로직'을 구현하지 않았음. 그냥 DB에서 순서대로 4개씩 가져오고 있는 상황. 이 부분을 구현하려면, 해당 사용자의 id를 통해 ```group_member``` 테이블에서 해당 사용자가 가입한 스터디 목록에 접근해서 4개씩 가져와야 하는데.. 한 번에 해당 사용자의 모든 스터디를 가져와 놓고 나눠서 제공하는 방법 말고 DB에서 4개씩 순서대로 가져오는 방법을 아직 찾지 못했음.
+ 임의로 수정한 study_group 테이블
![db_ssr - 복사본](https://user-images.githubusercontent.com/75300807/126862926-687223da-8b11-474f-9f13-1387b6578497.png)




### 진행 흐름

1. 사용자가 최초 마이페이지 방문 시(```/mypage```), 서버는 ```routes/mypage.js```에서 DB로부터 4개의 '진행 중인 스터디' 데이터를 가져와 ```mypage.ejs```에 전달한다. (```lead-group-list.ejs```에) 
2. 서버는 해당 데이터가 적용된 ```mypage.ejs``` 파일을 res.render 한다. (만약 사용자의 진행 중인 스터디가 없다면, 코드에서 조건문 분기를 나누어 '진행 중인 스터디가 없습니다'를 대신 출력하도록 적용할 계획)
3. 사용자가 ```더 보기``` 버튼을 클릭하면, 쿼리 스트링 파라미터를 담아 ```/mypage?reload=true```  서버에 요청을 보낸다. 
4. 서버는 ```routes/mypage.js```에서 ```request```에 쿼리 스트링 파라미터가 있는 경우 DB에서 추가로 4개의 '진행 중인 스터디' 데이터를 가져온다. 이때 ```idx``` 변수를 사용하여 기존에 꺼내왔던 스터디의 다음 번째 스터디부터 4개를 꺼내온다. (/routes/mypage.js 코드 참고)
5. ```더 보기``` 버튼을 클릭할 때마다 3번을 반복한다. '진행 중인 스터디' 개수보다 더 보기 버튼을 더 많이 누르는 경우는 데이터 요청을 막는다. (현재는 이 부분 처리해두지 않았음)
6. 만약 사용자가 다른 페이지로 이동했다가 다시 마이페이지에 방문하는 경우(즉, /mypage에 쿼리스트링 파라미터가 없는 경우) ```idx``` 변수가 초기화되어 다시 1번부터 4번 스터디만 출력한다.

### 작동 테스트
![mypage_ssr](https://user-images.githubusercontent.com/75300807/126861739-9b614295-153f-4677-b432-74fe812412af.gif)

