### PR TITLE
Issue/#86

### DIFF
--- a/public/css/group-edit.css
+++ b/public/css/group-edit.css
@@ -47,7 +47,7 @@
   backdrop-filter: blur(2px);
 }
 
-.group-create-submit__btn {
+.group-edit-submit__btn {
   width: var(--submit-width);
   height: var(--submit-height);
 }

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -49,7 +49,38 @@ function initialChange(e) {
 }
 
 function editSubmit(e) {
-  editForm.submit();
+  const groupId = window.location.pathname.split('/')[3];
+  const groupName = nameInput.value;
+  const main = document.querySelector(
+    '.group-edit-main-category option:checked'
+  ).value;
+  const sub = document.querySelector(
+    '.group-edit-sub-category option:checked'
+  ).value;
+  const gender = document.querySelector(
+    '.group-edit-option-gender option:checked'
+  ).value;
+  const location = document.querySelector(
+    '.group-edit-option-location option:checked'
+  ).value;
+  const members = document.querySelector(
+    '.group-edit-option-members option:checked'
+  ).value;
+  fetch(`http://localhost:3000/mypage/edit_process`, {
+    method: 'POST',
+    body: [groupId, groupName, main, sub, gender, location, members]
+  })
+    .then(res => res.json())
+    .then(status => submitAlert(status));
+}
+
+function submitAlert(isSubmit) {
+  if (isSubmit) {
+    location.href = 'http://localhost:3000/mypage';
+    alert('정상적으로 수정되었습니다');
+  } else {
+    alert('현재 인원수보다 정원이 적을 수 없습니다.');
+  }
 }
 
 function checkSubmit(e) {
@@ -92,17 +123,6 @@ function kickoutAlert(message) {
   }
 }
 
-function alertMsg() {
-  const status = new URLSearchParams(location.search).get('status');
-  if (status) {
-    switch (status) {
-      case 'invalidmembers':
-        alert('현재 인원수보다 정원이 적을 수 없습니다.');
-        break;
-    }
-  }
-}
-
 function changeListener(e) {
   submitBtn.disabled = false;
 }
@@ -123,7 +143,6 @@ function init() {
   nameInput.onkeypress = function () {
     submitBtn.disabled = true;
   };
-  alertMsg();
 }
 
 init();

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -116,6 +116,7 @@ function kickoutAlert(message) {
   if (message === 'ismanager') {
     alert('방장. 추후 참여중인 멤버에서 방장은 삭제 예정');
   } else if (message === 'kickout') {
+    location.href = 'http://localhost:3000/mypage';
     alert('해당 멤버를 강퇴하였습니다.');
   } else {
     alert(message);

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -137,9 +137,9 @@ function init() {
     location.href = 'http://localhost:3000/mypage';
   });
   submitBtn.addEventListener('click', editSubmit);
-  for (let i = 0; i < kickoutBtnAll.length; i++) {
-    kickoutBtnAll[i].addEventListener('click', kickoutSubmit);
-  }
+  kickoutBtnAll.forEach(btn => {
+    btn.addEventListener('click', kickoutSubmit);
+  });
   editForm.addEventListener('change', changeListener);
   checkBtn.addEventListener('click', checkSubmit);
   nameInput.onkeypress = function () {

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -3,10 +3,12 @@ const cat_sub = document.querySelector('.group-edit-sub-category');
 const sub_value = document.querySelector(
   '.group-edit-sub-category__input'
 ).value;
+const backBtn = document.querySelector('.group-edit__back-btn');
 const submitBtn = document.querySelector('.group-edit-submit__btn');
 const editForm = document.querySelector('.group-edit-form');
-const kickoutForm = document.querySelector('.group-edit-member__form');
-const kickoutBtn = document.querySelector('.group-edit-member-action__kickout');
+const kickoutBtnAll = document.querySelectorAll(
+  '.group-edit-member-action__kickout'
+);
 const checkForm = document.querySelector('.name-check-form');
 const checkBtn = document.querySelector('.name-check-btn');
 const nameInput = document.querySelector('.group-edit-name__input');
@@ -52,31 +54,33 @@ function editSubmit(e) {
 }
 
 function checkSubmit(e) {
-  checkForm.submit();
+  const groupId = window.location.pathname.split('/')[3];
+  const groupName = nameInput.value;
+  fetch(`http://localhost:3000/mypage/group-edit/` + groupId, {
+    method: 'POST',
+    body: [groupName, groupId]
+  })
+    .then(res => res.json())
+    .then(status => submitCheck(status));
+}
+
+function submitCheck(isValid) {
+  if (isValid) {
+    alert('사용 가능한 스터디명입니다.');
+    submitBtn.disabled = false;
+  } else {
+    alert('이미 사용 중인 스터디명입니다.');
+  }
 }
 
 function kickoutSubmit(e) {
-  kickoutForm.submit();
+  this.closest('.group-edit-member__form').submit();
 }
 
-function submitCheck() {
-  console.log(isValid);
-  if (isValid) {
-    submitBtn.disabled = false;
-  }
-}
 function alertMsg() {
   const status = new URLSearchParams(location.search).get('status');
   if (status) {
     switch (status) {
-      case 'invalidname':
-        alert('이미 사용 중인 스터디명입니다.');
-        break;
-      case 'validname':
-        alert('사용 가능한 스터디명입니다.');
-        isValid = 1;
-        submitCheck();
-        break;
       case 'invalidmembers':
         alert('현재 인원수보다 정원이 적을 수 없습니다.');
         break;
@@ -97,7 +101,9 @@ function init() {
     window.history.back();
   });
   submitBtn.addEventListener('click', editSubmit);
-  kickoutBtn.addEventListener('click', kickoutSubmit);
+  for (let i = 0; i < kickoutBtnAll.length; i++) {
+    kickoutBtnAll[i].addEventListener('click', kickoutSubmit);
+  }
   checkBtn.addEventListener('click', checkSubmit);
   nameInput.onkeypress = function () {
     submitBtn.disabled = true;

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -3,7 +3,7 @@ const cat_sub = document.querySelector('.group-edit-sub-category');
 const sub_value = document.querySelector(
   '.group-edit-sub-category__input'
 ).value;
-const submitBtn = document.querySelector('.group-create-submit__btn');
+const submitBtn = document.querySelector('.group-edit-submit__btn');
 const editForm = document.querySelector('.group-edit-form');
 const kickoutForm = document.querySelector('.group-edit-member__form');
 const kickoutBtn = document.querySelector('.group-edit-member-action__kickout');

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -9,7 +9,6 @@ const editForm = document.querySelector('.group-edit-form');
 const kickoutBtnAll = document.querySelectorAll(
   '.group-edit-member-action__kickout'
 );
-const optionsAll = document.querySelectorAll('select');
 const checkForm = document.querySelector('.name-check-form');
 const checkBtn = document.querySelector('.name-check-btn');
 const nameInput = document.querySelector('.group-edit-name__input');

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -132,7 +132,7 @@ function init() {
   cat_main.addEventListener('change', categoryChange);
   document.addEventListener('DOMContentLoaded', initialChange);
   backBtn.addEventListener('click', () => {
-    window.history.back();
+    location.href = 'http://localhost:3000/mypage';
   });
   submitBtn.addEventListener('click', editSubmit);
   for (let i = 0; i < kickoutBtnAll.length; i++) {

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -9,6 +9,7 @@ const editForm = document.querySelector('.group-edit-form');
 const kickoutBtnAll = document.querySelectorAll(
   '.group-edit-member-action__kickout'
 );
+const optionsAll = document.querySelectorAll('select');
 const checkForm = document.querySelector('.name-check-form');
 const checkBtn = document.querySelector('.name-check-btn');
 const nameInput = document.querySelector('.group-edit-name__input');
@@ -18,8 +19,6 @@ const lang = ['영어', '중국어', '일본어'];
 const employ = ['경영/사무', 'IT/인터넷', '마케팅', '디자인', '미디어'];
 const hobby = ['독서', '토론', '기타'];
 const exam = ['고1', '고2', '고3', 'N수'];
-
-let isValid = 0;
 
 function setSub(mainValue) {
   let val = ['전체'];
@@ -56,15 +55,15 @@ function editSubmit(e) {
 function checkSubmit(e) {
   const groupId = window.location.pathname.split('/')[3];
   const groupName = nameInput.value;
-  fetch(`http://localhost:3000/mypage/group-edit/` + groupId, {
+  fetch(`http://localhost:3000/mypage/name-check`, {
     method: 'POST',
     body: [groupName, groupId]
   })
     .then(res => res.json())
-    .then(status => submitCheck(status));
+    .then(status => checkAlert(status, groupName));
 }
 
-function submitCheck(isValid) {
+function checkAlert(isValid, name) {
   if (isValid) {
     alert('사용 가능한 스터디명입니다.');
     submitBtn.disabled = false;
@@ -74,7 +73,23 @@ function submitCheck(isValid) {
 }
 
 function kickoutSubmit(e) {
-  this.closest('.group-edit-member__form').submit();
+  const memberId = this.previousElementSibling.value;
+  fetch(`http://localhost:3000/mypage/kickout`, {
+    method: 'POST',
+    body: memberId
+  })
+    .then(res => res.json())
+    .then(result => kickoutAlert(result[0]));
+}
+
+function kickoutAlert(message) {
+  if (message === 'ismanager') {
+    alert('방장. 추후 참여중인 멤버에서 방장은 삭제 예정');
+  } else if (message === 'kickout') {
+    alert('해당 멤버를 강퇴하였습니다.');
+  } else {
+    alert(message);
+  }
 }
 
 function alertMsg() {
@@ -84,17 +99,16 @@ function alertMsg() {
       case 'invalidmembers':
         alert('현재 인원수보다 정원이 적을 수 없습니다.');
         break;
-      case 'ismanager':
-        alert('방장. 추후 참여중인 멤버에서 방장은 삭제 예정');
-        break;
-      case 'kickout':
-        alert('해당 멤버를 강퇴하였습니다.');
-        break;
     }
   }
 }
 
+function changeListener(e) {
+  submitBtn.disabled = false;
+}
+
 function init() {
+  submitBtn.disabled = true;
   cat_main.addEventListener('change', categoryChange);
   document.addEventListener('DOMContentLoaded', initialChange);
   backBtn.addEventListener('click', () => {
@@ -104,6 +118,7 @@ function init() {
   for (let i = 0; i < kickoutBtnAll.length; i++) {
     kickoutBtnAll[i].addEventListener('click', kickoutSubmit);
   }
+  editForm.addEventListener('change', changeListener);
   checkBtn.addEventListener('click', checkSubmit);
   nameInput.onkeypress = function () {
     submitBtn.disabled = true;

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -93,6 +93,9 @@ function alertMsg() {
 function init() {
   cat_main.addEventListener('change', categoryChange);
   document.addEventListener('DOMContentLoaded', initialChange);
+  backBtn.addEventListener('click', () => {
+    window.history.back();
+  });
   submitBtn.addEventListener('click', editSubmit);
   kickoutBtn.addEventListener('click', kickoutSubmit);
   checkBtn.addEventListener('click', checkSubmit);

--- a/public/js/group-edit.js
+++ b/public/js/group-edit.js
@@ -12,27 +12,29 @@ const kickoutBtnAll = document.querySelectorAll(
 const checkForm = document.querySelector('.name-check-form');
 const checkBtn = document.querySelector('.name-check-btn');
 const nameInput = document.querySelector('.group-edit-name__input');
-// 얘네도 바뀔때마다 받아오거나 수정해야 할 것 같다
-const office = ['9급', '7급', '5급'];
-const lang = ['영어', '중국어', '일본어'];
-const employ = ['경영/사무', 'IT/인터넷', '마케팅', '디자인', '미디어'];
-const hobby = ['독서', '토론', '기타'];
-const exam = ['고1', '고2', '고3', 'N수'];
+
+const subCatList = {
+  office: ['9급', '7급', '5급'],
+  lang: ['영어', '중국어', '일본어'],
+  employ: ['경영/사무', 'IT/인터넷', '마케팅', '디자인', '미디어'],
+  hobby: ['독서', '토론', '기타'],
+  exam: ['고1', '고2', '고3', 'N수']
+};
 
 function setSub(mainValue) {
   let val = ['전체'];
-  if (mainValue === '공무원') val = office;
-  else if (mainValue === '어학') val = lang;
-  else if (mainValue === '취업') val = employ;
-  else if (mainValue === '취미') val = hobby;
-  else if (mainValue === '수능') val = exam;
+  if (mainValue === '공무원') val = subCatList.office;
+  else if (mainValue === '어학') val = subCatList.lang;
+  else if (mainValue === '취업') val = subCatList.employ;
+  else if (mainValue === '취미') val = subCatList.hobby;
+  else if (mainValue === '수능') val = subCatList.exam;
 
   cat_sub.options.length = 0;
-  for (let x in val) {
+  for (const sub_category of val) {
     let opt = document.createElement('option');
-    opt.value = val[x];
-    opt.textContent = val[x];
-    if (sub_value === val[x]) opt.selected = true;
+    opt.value = sub_category;
+    opt.textContent = sub_category;
+    if (sub_value === sub_category) opt.selected = true;
     cat_sub.appendChild(opt);
   }
 }

--- a/routes/mypage.js
+++ b/routes/mypage.js
@@ -158,35 +158,41 @@ router.post('/name-check', (req, res, next) => {
     if (result[0][0].used && result[1][0].name !== name) {
       res.send('0');
     } else {
-      const sql_name_edit = 'UPDATE study_group SET name=? WHERE id=?';
-      db.query(sql_name_edit, [name, id], err => {
-        if (err) {
-          next(err);
-        }
-        res.send('1');
-      });
+      res.send('1');
     }
   });
 });
 
 router.post('/edit_process', (req, res, next) => {
-  console.log(req.body);
-  const { id, main, sub, gender, location, members } = req.body;
+  // { id, name, main, sub, gender, location, members }
+  const studyInfo = req.body.split(',');
   const sql_number = 'SELECT * FROM study_group WHERE id=?';
-  db.query(sql_number, [id], (err, result) => {
+  db.query(sql_number, [studyInfo[0]], (err, result) => {
     if (err) {
       next(err);
-    } else if (result[0].current_number > parseInt(members)) {
-      res.redirect('/mypage/group-edit/' + id + '?stauts=invlaidmembers');
+    } else if (result[0].current_number > parseInt(studyInfo[6])) {
+      res.send('0');
     } else {
       const sql_edit =
-        'UPDATE study_group SET main_category=?, sub_category=?, gender=?, location=?, maximum_number=? WHERE id=?';
-      db.query(sql_edit, [main, sub, gender, location, members, id], err => {
-        if (err) {
-          next(err);
+        'UPDATE study_group SET name=?, main_category=?, sub_category=?, gender=?, location=?, maximum_number=? WHERE id=?';
+      db.query(
+        sql_edit,
+        [
+          studyInfo[1],
+          studyInfo[2],
+          studyInfo[3],
+          studyInfo[4],
+          studyInfo[5],
+          studyInfo[6],
+          studyInfo[0]
+        ],
+        err => {
+          if (err) {
+            next(err);
+          }
+          res.send('1');
         }
-        res.redirect('/mypage/?status=edit');
-      });
+      );
     }
   });
 });

--- a/routes/mypage.js
+++ b/routes/mypage.js
@@ -207,6 +207,25 @@ router.post('/kickout', (req, res, next) => {
       if (result[0].is_manager) {
         res.send(['ismanager']);
       } else {
+        // Kickout 이후 current_number -1
+        const groupId = result[0].study_group_id;
+        const sql_current_number = 'SELECT * FROM study_group WHERE id=?';
+        db.query(sql_current_number, [groupId], (err, result) => {
+          if (err) {
+            next(err);
+          } else {
+            const currentNum = result[0].current_number;
+            const sql_update_number =
+              'UPDATE study_group SET current_number=? WHERE id=?';
+            db.query(
+              sql_update_number,
+              [currentNum - 1, groupId],
+              (err, result) => {
+                if (err) next(err);
+              }
+            );
+          }
+        });
         const sql_kickout = 'DELETE FROM group_member WHERE id=?';
         db.query(sql_kickout, [memberId], err => {
           if (err) {

--- a/routes/mypage.js
+++ b/routes/mypage.js
@@ -146,8 +146,9 @@ router.get('/group-edit/:id', (req, res, next) => {
   );
 });
 
-router.post('/edit_check', (req, res, next) => {
-  const { id, name } = req.body;
+router.post('/group-edit/:id', (req, res, next) => {
+  const name = req.body.split(',')[0];
+  const id = req.body.split(',')[1];
   const sql_name = 'SELECT COUNT(*) as used FROM study_group WHERE name=?;';
   const sql_number = 'SELECT * FROM study_group WHERE id=?';
   db.query(sql_name + sql_number, [name, id], (err, result) => {
@@ -155,14 +156,14 @@ router.post('/edit_check', (req, res, next) => {
       next(err);
     }
     if (result[0][0].used && result[1][0].name !== name) {
-      res.redirect('/mypage/group-edit/' + id + '?status=invalidname');
+      res.send('0');
     } else {
       const sql_name_edit = 'UPDATE study_group SET name=? WHERE id=?';
       db.query(sql_name_edit, [name, id], err => {
         if (err) {
           next(err);
         }
-        res.redirect('/mypage/group-edit/' + id + '?status=validname');
+        res.send('1');
       });
     }
   });

--- a/routes/mypage.js
+++ b/routes/mypage.js
@@ -146,7 +146,7 @@ router.get('/group-edit/:id', (req, res, next) => {
   );
 });
 
-router.post('/group-edit/:id', (req, res, next) => {
+router.post('/name-check', (req, res, next) => {
   const name = req.body.split(',')[0];
   const id = req.body.split(',')[1];
   const sql_name = 'SELECT COUNT(*) as used FROM study_group WHERE name=?;';
@@ -192,27 +192,21 @@ router.post('/edit_process', (req, res, next) => {
 });
 
 router.post('/kickout', (req, res, next) => {
-  console.log(req.body);
-  const { memberid } = req.body;
+  const memberId = req.body;
   const sql_member = 'SELECT * FROM group_member WHERE id=?';
-  db.query(sql_member, [memberid], (err, result) => {
+  db.query(sql_member, [memberId], (err, result) => {
     if (err) {
       next(err);
     } else {
-      const study_group_id = result[0].study_group_id;
       if (result[0].is_manager) {
-        res.redirect(
-          '/mypage/group-edit/' + study_group_id + '?status=ismanager'
-        );
+        res.send(['ismanager']);
       } else {
         const sql_kickout = 'DELETE FROM group_member WHERE id=?';
-        db.query(sql_kickout, [memberid], err => {
+        db.query(sql_kickout, [memberId], err => {
           if (err) {
             next(err);
           }
-          res.redirect(
-            '/mypage/group-edit/' + study_group_id + '?status=kickout'
-          );
+          res.send(['kickout']);
         });
       }
     }

--- a/views/group-edit.ejs
+++ b/views/group-edit.ejs
@@ -114,13 +114,9 @@
             </div>
           </div>
           <div class="group-edit-member-action">
-            <form
-              action="/mypage/kickout"
-              method="POST"
-              class="group-edit-member__form"
-            >
               <input
                 type="hidden"
+                class="group-edit-member__input"
                 name="memberid"
                 value="<%= member[i].id %>"
               />

--- a/views/group-edit.ejs
+++ b/views/group-edit.ejs
@@ -132,7 +132,7 @@
         <% } %>
       </section>
       <section class="group-edit-submit">
-        <button class="group-create-submit__btn" type="button" disabled>
+        <button class="group-edit-submit__btn" type="button">
           수정완료
         </button>
       </section>

--- a/views/group-edit.ejs
+++ b/views/group-edit.ejs
@@ -15,14 +15,14 @@
         <span>스터디 관리</span>
         <button class="group-edit__back-btn" type="button">뒤로가기</button>
       </section>
+      <input type="hidden" name="id" value="<%=id%>" />
       <form action="/mypage/edit_process" method="POST" class="group-edit-form">
         <input type="hidden" name="id" value="<%=id%>" />
         <section class="group-edit-category">
           <select class="group-edit-main-category" name="main">
             <option value="" disabled selected>대분류</option>
             <% let mainCategoryList = ["공무원", "어학", "취업", "수능",
-            "취미"]; let mainValue =
-            ["officiary","language","employee","exam","hobby"]; for (let i = 0;
+            "취미"]; for (let i = 0;
             i < mainCategoryList.length; i++) { if(mainCategoryList[i] === main)
             { %>
             <option value="<%= mainCategoryList[i] %>" selected>
@@ -89,13 +89,10 @@
           </select>
         </form>
         </section>
-        <form action="/mypage/edit_check" method="POST" class="name-check-form">
-          <input type="hidden" name="id" value="<%=id%>" />
-          <section class="group-edit-name">
-            <input class="group-edit-name__input" placeholder="스터디 이름" name="name" value="<%= name %>" />
-            <button class="name-check-btn" type="button">중복체크</button>
-          </section>
-        </form>
+        <section class="group-edit-name">
+          <input class="group-edit-name__input" placeholder="스터디 이름" name="name" value="<%= name %>" />
+          <button class="name-check-btn" type="button">중복체크</button>
+        </section>
       <section class="group-edit-members">
         <span>참여중인 멤버</span>
         <hr />

--- a/views/group-edit.ejs
+++ b/views/group-edit.ejs
@@ -11,6 +11,10 @@
   </head>
   <body>
     <main class="group-edit">
+      <section class="header">
+        <span>스터디 관리</span>
+        <button class="group-edit__back-btn" type="button">뒤로가기</button>
+      </section>
       <form action="/mypage/edit_process" method="POST" class="group-edit-form">
         <input type="hidden" name="id" value="<%=id%>" />
         <section class="group-edit-category">

--- a/views/group-edit.ejs
+++ b/views/group-edit.ejs
@@ -16,7 +16,7 @@
         <button class="group-edit__back-btn" type="button">뒤로가기</button>
       </section>
       <input type="hidden" name="id" value="<%=id%>" />
-      <form action="/mypage/edit_process" method="POST" class="group-edit-form">
+      <form class="group-edit-form">
         <input type="hidden" name="id" value="<%=id%>" />
         <section class="group-edit-category">
           <select class="group-edit-main-category" name="main">
@@ -45,33 +45,31 @@
           </select>
         </section>
         <section class="group-edit-options">
-          <select class="group-edit-option" name="location">
+          <select class="group-edit-option-location">
             <option value="" disabled selected>온/오프라인</option>
-            <% let locationList = ["온라인","오프라인"]; let locationValue
-            =["online","offline"]; for (let i = 0; i < locationValue.length;
-            i++) { if(locationValue[i] === location) { %>
-            <option value="<%= locationValue[i] %>" selected>
+            <% let locationList = ["온라인","오프라인"]; for (let i = 0; i < locationList.length;
+            i++) { if(locationList[i] === location) { %>
+            <option value="<%= locationList[i] %>" selected>
               <%= locationList[i] %>
             </option>
             <% } else { %>
-            <option value="<%= locationValue[i] %>">
+            <option value="<%= locationList[i] %>">
               <%= locationList[i] %>
             </option>
             <% } } %>
           </select>
-          <select class="group-edit-option" name="gender">
+          <select class="group-edit-option-gender">
             <option value="" disabled selected>성별</option>
-            <% let genderList = ["남성만","여성만","상관없음"]; let genderValue
-            =["male","female","both"]; for (let i = 0; i < genderValue.length;
-            i++) { if(genderValue[i] === gender) { %>
-            <option value="<%= genderValue[i] %>" selected>
+            <% let genderList = ["남성만","여성만","상관없음"]; for (let i = 0; i < genderList.length;
+            i++) { if(genderList[i] === gender) { %>
+            <option value="<%= genderList[i] %>" selected>
               <%= genderList[i] %>
             </option>
             <% } else { %>
-            <option value="<%= genderValue[i] %>"><%= genderList[i] %></option>
+            <option value="<%= genderList[i] %>"><%= genderList[i] %></option>
             <% } } %>
           </select>
-          <select class="group-edit-option" name="members">
+          <select class="group-edit-option-members">
             <option value="" disabled selected>인원수</option>
             <% let maximumNumberList =
             ["2명","3명","4명","5명","6명","7명","8명","9명"]; let


### PR DESCRIPTION
group-edit의 과정에서 발생하는 여러 문제들을 해결했습니다.
특히 그 중에서도 다른 카테고리를 변경한 후에 스터디명 중복체크를 하는 경우 새로고침에 의해 바꾼 값들이 저장되지 않는 문제를 해결했습니다.

## 작은 수정들
* 수정 완료 버튼의 class가 `group-create-submit`이던 것을 `group-edit-submit`으로 수정하였습니다.
* group-edit 페이지에 뒤로가기 버튼을 추가하였습니다. `location.href = 'http://localhost:3000/mypage/group-edit';`
* location, gender의 select의 class를 수정하고, name을 삭제하였습니다. 또한, value를 영문에서 한글로 바꾸어주었습니다.
* `editForm` 내부의 각 select tag가 바뀌는 경우, disabled 처리되었던 수정완료 버튼을 disabled = false;로 바꾸어주었습니다.
 따라서, 스터디 명 중복체크를 해야만 수정완료가 가능했던 issue를 해결했습니다.

## 큰 수정
* `URLSearchParams`를 통해서 `form`을 submit하여 구현하던 강퇴, 중복체크, 스터디 수정의 기능을 모두 `fetch`와 `then`을 활용하여 처리하도록 했습니다.
이를 통해서 새로고침 없이 기능들이 동작하도록 했고, 강퇴 이후와 수정완료시에는 alert과 함께 mypage로 이동되도록 수정하였습니다.